### PR TITLE
Mention -DBUILD_SHARED_LIBS in cmake of dlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone git@github.com:davisking/dlib.git
 cd dlib/dlib
 mkdir build
 cd build
-cmake ..
+cmake -DBUILD_SHARED_LIBS=ON ..
 make
 sudo make install
 ```


### PR DESCRIPTION
Unless this is added, dlib will not be built using -fPIC and will not be able to be linked with PHP later.