### PR TITLE
Fix git -> https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Install Dlib as shared library
 
 ```bash
-git clone git@github.com:davisking/dlib.git
+git clone https://github.com/davisking/dlib.git
 cd dlib/dlib
 mkdir build
 cd build


### PR DESCRIPTION
People usually don't have access to Github for DLib, so previous command will not work out-of-box. Better to suggest https:// alternative