### PR TITLE
Update pdlib installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ git clone https://github.com/goodspb/pdlib.git
 cd pdlib
 phpize
 ./configure --enable-debug
+# you may need to indicate the dlib install location
+# PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-debug
 make
 sudo make install
 ```


### PR DESCRIPTION
Just doing `./configure --enable-debug` fails with `configure: error: dlib-1 not found`.
Needed to indicate the dlib install location for it to work
`PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-debug`
I got it from https://discuss.getsol.us/d/5423-compiled-library-not-found